### PR TITLE
fix broken scrolling

### DIFF
--- a/src/map/components/landscape/categoryRows.component.tsx
+++ b/src/map/components/landscape/categoryRows.component.tsx
@@ -1,7 +1,7 @@
-import React, {useEffect} from 'react';
+import React from 'react';
 import ServiceButton from './servicebutton.component';
-import {Providers, DemoData} from '../../../assets/data/dataType';
-import {TableRow, TableCell, createStyles} from '@material-ui/core';
+import {DemoData, Providers} from '../../../assets/data/dataType';
+import {createStyles, TableCell, TableRow} from '@material-ui/core';
 import {makeStyles} from '@material-ui/styles';
 
 interface Props {
@@ -25,16 +25,8 @@ const useStyles = makeStyles(
   })
 );
 
-function CategoryRow(props: Props) {
-  const firstUnfilteredService = React.createRef<HTMLButtonElement>();
+function CategoryRows(props: Props) {
   const classes = useStyles({zoomFactor: props.zoomFactor});
-
-  useEffect(() => {
-    firstUnfilteredService.current?.scrollIntoView({
-      behavior: 'smooth',
-      block: 'nearest',
-    });
-  });
 
   const getServicesByProviderAndCategory = (
     provider: Providers,
@@ -67,10 +59,8 @@ function CategoryRow(props: Props) {
                       service={service}
                       setDetailService={props.setDetailService}
                       isFiltered={isFiltered}
-                      buttonRef={
-                        isFirstUnfiltered ? firstUnfilteredService : undefined
-                      }
                       zoomFactor={props.zoomFactor}
+                      shouldScroll={isFirstUnfiltered}
                     />
                   );
                 }
@@ -83,7 +73,7 @@ function CategoryRow(props: Props) {
   );
 }
 
-export default React.memo(CategoryRow, (prevProps, nextProps) => {
+export default React.memo(CategoryRows, (prevProps, nextProps) => {
   return (
     prevProps.filteredContent === nextProps.filteredContent &&
     prevProps.zoomFactor === nextProps.zoomFactor

--- a/src/map/components/landscape/landscape.component.tsx
+++ b/src/map/components/landscape/landscape.component.tsx
@@ -7,7 +7,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import {Typography} from '@material-ui/core';
 import {DemoData, Providers} from '../../../assets/data/dataType';
-import CategoryRow from './categoryRow.component';
+import CategoryRow from './categoryRows.component';
 
 interface Props {
   setDetailService: (service: DemoData) => void;

--- a/src/map/components/landscape/servicebutton.component.tsx
+++ b/src/map/components/landscape/servicebutton.component.tsx
@@ -33,7 +33,7 @@ function ServiceButton(props: Props) {
         block: 'nearest',
       });
     setDidScroll(props.shouldScroll);
-  });
+  }, [didScroll, props.shouldScroll, buttonRef]);
 
   return (
     <Tooltip title={props.service.service}>

--- a/src/map/components/landscape/servicebutton.component.tsx
+++ b/src/map/components/landscape/servicebutton.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect, useState} from 'react';
 import {IconButton, Tooltip} from '@material-ui/core';
 import {DemoData} from '../../../assets/data/dataType';
 import styled from 'styled-components';
@@ -7,9 +7,9 @@ import LazyLoad from 'react-lazyload';
 interface Props {
   service: DemoData;
   setDetailService: (service: DemoData) => void;
-  buttonRef?: React.RefObject<HTMLButtonElement>;
   isFiltered: boolean;
   zoomFactor: number;
+  shouldScroll: boolean;
 }
 
 const ServiceIconButton = styled(IconButton)({padding: 3});
@@ -22,14 +22,25 @@ const ServiceIcon = styled.img<{filtered: boolean; zoomFactor: number}>(
 );
 
 function ServiceButton(props: Props) {
+  const buttonRef = React.createRef<HTMLButtonElement>();
+
   const setDetailService = () => props.setDetailService(props.service);
+  const [didScroll, setDidScroll] = useState(false);
+  useEffect(() => {
+    if (!didScroll && props.shouldScroll)
+      buttonRef?.current?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+    setDidScroll(props.shouldScroll);
+  });
 
   return (
     <Tooltip title={props.service.service}>
       <ServiceIconButton
         aria-label={props.service.service}
         onClick={setDetailService}
-        ref={props.buttonRef}
+        ref={buttonRef}
       >
         <LazyLoad height={25}>
           <ServiceIcon
@@ -47,6 +58,7 @@ function ServiceButton(props: Props) {
 export default React.memo(ServiceButton, (prevProps, nextProps) => {
   return (
     prevProps.isFiltered === nextProps.isFiltered &&
-    prevProps.zoomFactor === nextProps.zoomFactor
+    prevProps.zoomFactor === nextProps.zoomFactor &&
+    prevProps.shouldScroll === nextProps.shouldScroll
   );
 });


### PR DESCRIPTION
Fixes #40. First, in most cases we did not scroll to the first unfiltered service anymore. Second, we often scrolled when the zoom changed. Both should be fixed by this PR.